### PR TITLE
Development of video mode switch has been completed

### DIFF
--- a/boot/stage1.asm
+++ b/boot/stage1.asm
@@ -229,7 +229,7 @@ ret
 ;; required data once and for all, if any kind of error was raised we report
 disk_error:
 
-    putl "disk_error"        ;; display disk error
+    putl "BOOT/STAGE1: <disk_error>"
     jmp _panic              ;; stop execution of bootloader
 
 ;; FUNCTION_PRINT_LINE(bp=STRING_POINTER, cx=LENGTH_OF_SPECIFIED STRING)

--- a/boot/stage2.asm
+++ b/boot/stage2.asm
@@ -1,5 +1,11 @@
 [BITS 16]           ;; work is still needed in real mode hence 16 bits
 
+%ifndef DEBUG
+    [ORG 0x1000]    ;; This is LEGACY BIOS implementation, which loads
+                    ;; bootable section into a predefined address of
+                    ;; 0x7c00 in memory.
+%endif
+
 jmp _start          ;; jump instruction just to make sure _start is run
                     ;; immidiately after jump to stage 2 was initiated
 
@@ -49,7 +55,19 @@ _start:
     xor ebx, ebx        ;; clear bx before use for mem_map entries
     call memory_map     ;; list all memory map for system
 
+    ;; call video_mode     ;; set video mode
+                        ;; For general development process we have
+                        ;; currently ignored this. may call this
+                        ;; in near future when screen rendering is
+                        ;; required
+
     jmp $
+
+video_mode:
+    mov ah, 0x00        ;; BIOS function: Set Video Mode
+    mov al, 0x13        ;; The video mode number (0x13 = VGA Graphics)
+    int 0x10            ;; Call BIOS video interrupt
+ret
 
 memory_map:
     pusha               ;; store context of call to make canges temp

--- a/boot/stage2.asm
+++ b/boot/stage2.asm
@@ -30,6 +30,8 @@ _start:
     mov ss, ax      ;; clean ss
     mov gs, ax      ;; clean gs
     
+    cld
+    
     mov ebp, 0x7c00 ;; previous stack pointer to newly created pointer
     mov esp, 0x7c00 ;; currnet stack pointer to beginning of stack
 
@@ -51,12 +53,13 @@ _start:
 
 memory_map:
     pusha               ;; store context of call to make canges temp
-
-    mov eax, 0xe820     ;; store instruction signifier into ax
-    mov edx, 0x534d4150 ;; store SMAP into dx as required by int 15h
-    mov ecx, 0x18       ;; store size for buffer that we provided
-    int 0x15            ;; call interrupt
-    jc .done            ;; carry signifies that we are done
+    
+    .next:
+        mov eax, 0xe820     ;; store instruction signifier into ax
+        mov edx, 0x534d4150 ;; store SMAP into dx as required by int 15h
+        mov ecx, 0x18       ;; store size for buffer that we provided
+        int 0x15            ;; call interrupt
+        jc .done            ;; carry signifies that we are done
     
     call print_map
 
@@ -66,7 +69,7 @@ memory_map:
                         ;; stack may get curropted so we terminate
 
     test ebx, ebx       ;; if ebx is 0 then listing has been completed
-    jnz memory_map      ;; comtinue and look for next entry in line
+    jnz .next           ;; comtinue and look for next entry in line
     
     .done:
         popa            ;; restore all context to the register

--- a/makefile
+++ b/makefile
@@ -20,6 +20,17 @@ default: setup bootlaoder
 bootlaoder:
 	$(MAKE) -C boot
 
+# create proper support for floppy and hard drive images, both 
+# have boot written at first sector and then within file system 
+# they must have STAGE2.SYS added to file system on images
+image: floppy hdrive
+
+floppy:
+	$(MAKE) -C boot FAT12 FAT12_DBG
+	dd if=/dev/zero of=out/FLOPPY.img bs=512 count=2880
+	mformat -i out/FLOPPY.img -f 1440 -B bin/BOOT::STAGE1::FAT12.SYS ::
+	mcopy -i out/FLOPPY.img bin/BOOT::STAGE2::FAT12.SYS ::/STAGE2.SYS
+
 setup:
 	mkdir -p ${BIN_DIR}
 	mkdir -p ${OUT_DIR}


### PR DESCRIPTION
Implement code to set the video mode in Real Mode for Stage 2 bootloader.

Use BIOS interrupts to select and enable optimal video mode.
Refer to VESA video modes and BIOS documentation.
Helpful links:

Tutorial: https://thejat.in/learn/changing-video-mode-using-bios
OSDev: https://wiki.osdev.org/VESA_Video_Modes

this merge request closes #5 